### PR TITLE
 Fix global Cypress namespace augumentation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-mailosaur",
-  "version": "1.0.5",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "src"
   ],
   "main": "index.js",
+  "types": "src/mailosaurCommands.d.ts",
   "scripts": {
     "coveralls": "cat ./coverage/lcov.info | coveralls",
     "lint": "node_modules/.bin/eslint src test/react-app/src test/react-app/cypress",

--- a/src/mailosaurCommands.d.ts
+++ b/src/mailosaurCommands.d.ts
@@ -1,5 +1,3 @@
-import { cypressCommands } from "./mailosaurCommands";
-
 /**
  * @class
  * Initializes a new instance of the SpamAssassinRule class.
@@ -231,10 +229,9 @@ export interface MessageListResult {
  * subject line.
  * @member {string} [body] The value to seek within the target email's HTML or
  * text body.
- * @member {string} [match] If set to ALL (default), then only results that match all 
- * specified criteria will be returned. If set to ANY, results that match any of the 
+ * @member {string} [match] If set to ALL (default), then only results that match all
+ * specified criteria will be returned. If set to ANY, results that match any of the
  * specified criteria will be returned.
-    
  */
 export interface SearchCriteria {
     sentFrom?: string;
@@ -295,109 +292,112 @@ export interface SearchOptions extends Cypress.Timeoutable {
     suppressError?: boolean
 }
 
-declare namespace Cypress {
-    interface Chainable {
-        /**
-         * @summary List all servers
-         *
-         * Returns a list of your virtual SMTP servers. Servers are returned sorted in
-         * alphabetical order.
-         *
-         */
-        mailosaurListServers(
-        ): Cypress.Chainable<ServerListResult>;
+declare global {
+    namespace Cypress {
+        interface Chainable {
+            /**
+             * @summary List all servers
+             *
+             * Returns a list of your virtual SMTP servers. Servers are returned sorted in
+             * alphabetical order.
+             *
+             */
+            mailosaurListServers(
+            ): Cypress.Chainable<ServerListResult>;
 
-        mailosaurCreateServer(
-            options: ServerCreateOptions
-        ): Cypress.Chainable<Server>;
+            mailosaurCreateServer(
+                options: ServerCreateOptions
+            ): Cypress.Chainable<Server>;
 
-        mailosaurGetServer(
-            serverId: string
-        ): Cypress.Chainable<Server>;
+            mailosaurGetServer(
+                serverId: string
+            ): Cypress.Chainable<Server>;
 
-        mailosaurUpdateServer(
-            server: Server
-        ): Cypress.Chainable<Server>;
+            mailosaurUpdateServer(
+                server: Server
+            ): Cypress.Chainable<Server>;
 
-        mailosaurDeleteServer(
-            serverId: string
-        ): Cypress.Chainable<null>;
+            mailosaurDeleteServer(
+                serverId: string
+            ): Cypress.Chainable<null>;
 
-        mailosaurDeleteAllMessages(
-            serverId: string
-        ): Cypress.Chainable<null>;
+            mailosaurDeleteAllMessages(
+                serverId: string
+            ): Cypress.Chainable<null>;
 
-        mailosaurListMessages(
-            serverId: string
-        ): Cypress.Chainable<MessageListResult>;
+            mailosaurListMessages(
+                serverId: string
+            ): Cypress.Chainable<MessageListResult>;
 
-        mailosaurCreateMessage(
-            serverId: string
-        ): Cypress.Chainable<Message>;
+            mailosaurCreateMessage(
+                serverId: string
+            ): Cypress.Chainable<Message>;
 
-        mailosaurGetMessage(
-            serverId: string,
-            criteria: SearchCriteria,
-            options?: SearchOptions
-        ): Cypress.Chainable<Message>;
+            mailosaurGetMessage(
+                serverId: string,
+                criteria: SearchCriteria,
+                options?: SearchOptions
+            ): Cypress.Chainable<Message>;
 
-        mailosaurGetMessageById(
-            messageId: string
-        ): Cypress.Chainable<Message>;
+            mailosaurGetMessageById(
+                messageId: string
+            ): Cypress.Chainable<Message>;
 
-        mailosaurSearchMessages(
-            serverId: string,
-            criteria: SearchCriteria,
-            options?: SearchOptions
-        ): Cypress.Chainable<MessageListResult>;
+            mailosaurSearchMessages(
+                serverId: string,
+                criteria: SearchCriteria,
+                options?: SearchOptions
+            ): Cypress.Chainable<MessageListResult>;
 
-        mailosaurGetMessagesBySubject(
-            serverId: string,
-            subject: string
-        ): Cypress.Chainable<MessageListResult>;
+            mailosaurGetMessagesBySubject(
+                serverId: string,
+                subject: string
+            ): Cypress.Chainable<MessageListResult>;
 
-        mailosaurGetMessagesByBody(
-            serverId: string,
-            body: string
-        ): Cypress.Chainable<MessageListResult>;
+            mailosaurGetMessagesByBody(
+                serverId: string,
+                body: string
+            ): Cypress.Chainable<MessageListResult>;
 
-        mailosaurGetMessagesBySentFrom(
-            serverId: string,
-            sentFrom: string
-        ): Cypress.Chainable<MessageListResult>;
+            mailosaurGetMessagesBySentFrom(
+                serverId: string,
+                sentFrom: string
+            ): Cypress.Chainable<MessageListResult>;
 
-        mailosaurGetMessagesBySentTo(
-            serverId: string,
-            sentTo: string
-        ): Cypress.Chainable<MessageListResult>;
+            mailosaurGetMessagesBySentTo(
+                serverId: string,
+                sentTo: string
+            ): Cypress.Chainable<MessageListResult>;
 
-        mailosaurDownloadAttachment(
-            attachmentId: string
-        ): Cypress.Chainable<Attachment>;
+            mailosaurDownloadAttachment(
+                attachmentId: string
+            ): Cypress.Chainable<Attachment>;
 
-        mailosaurDownloadMessage(
-            messageId: string
-        ): Cypress.Chainable<string>;
+            mailosaurDownloadMessage(
+                messageId: string
+            ): Cypress.Chainable<string>;
 
-        mailosaurDeleteMessage(
-            messageId: string
-        ): Cypress.Chainable<null>;
+            mailosaurDeleteMessage(
+                messageId: string
+            ): Cypress.Chainable<null>;
 
-        /**
-         * @summary Perform a spam test
-         *
-         * Perform spam testing on the specified email
-         *
-         * @param {string} messageId The identifier of the email to be analyzed.
-         *
-         * @returns {Chainable<SpamAnalysisResult>}
-         */
-        mailosaurGetSpamAnalysis(
-            messageId: string
-        ): Chainable<SpamAnalysisResult>;
+            /**
+             * @summary Perform a spam test
+             *
+             * Perform spam testing on the specified email
+             *
+             * @param {string} messageId The identifier of the email to be analyzed.
+             *
+             * @returns {Chainable<SpamAnalysisResult>}
+             */
+            mailosaurGetSpamAnalysis(
+                messageId: string
+            ): Chainable<SpamAnalysisResult>;
 
-        mailosaurGenerateEmailAddress(
-            serverId: string
-        ): Cypress.Chainable<string>;
+            mailosaurGenerateEmailAddress(
+                serverId: string
+            ): Cypress.Chainable<string>;
+        }
+
     }
 }


### PR DESCRIPTION
This is fixed with 2 things:

1. For global namespace augumentation to work correctly, the augumentation needs to be in an "ambient" context (vs module context).
You can achieve ambient context in d.ts files in 2 ways:
  a.) by not using import/export keywords (using them toggles module context)
  b.) by wrapping namespace augumentation in `declare global {}` block - ambient context is inside this block.

See more info here:
- https://www.typescriptlang.org/docs/handbook/release-notes/typescript-1-8.html#augmenting-globalmodule-scope-from-modules
- microsoft/TypeScript-Handbook#180 (comment)

2. For Typescript to be able to use provided type declarations, we need to point it to a correct d.ts file.
This is done by specifying path to this file in package.json's field "types".
With this, an application just needs to `import 'cypress-mailosaur'` and types just work

fixes #12 