### PR TITLE
Added timeout property to SearchOptions

### DIFF
--- a/src/mailosaurCommands.d.ts
+++ b/src/mailosaurCommands.d.ts
@@ -289,6 +289,7 @@ export interface ServerCreateOptions {
 }
 
 export interface SearchOptions extends Cypress.Timeoutable {
+    timeout?: number,
     receivedAfter?: Date,
     page?: number,
     itemsPerPage?: number,


### PR DESCRIPTION
Currently if I use `cy.mailosaurGetMessage()` with `timeout` option IDE shows it as an Error